### PR TITLE
refactor(serializer)!: rename Question.category -> category_id in API

### DIFF
--- a/backend/apps/gameplay/serializers.py
+++ b/backend/apps/gameplay/serializers.py
@@ -9,11 +9,15 @@ class QuestionCategorySerializer(serializers.ModelSerializer):
 
 
 class QuestionSerializer(serializers.ModelSerializer):
-    category = serializers.PrimaryKeyRelatedField(queryset=QuestionCategory.objects.all())
+    category_id = serializers.PrimaryKeyRelatedField(
+        source='category',
+        queryset=QuestionCategory.objects.all(),
+        required=True
+    )
 
     class Meta:
         model = Question
-        fields = ['id', 'text', 'question_type', 'category']
+        fields = ['id', 'text', 'question_type', 'category_id']
 
 
 class QuestionRequestSerializer(serializers.Serializer):

--- a/backend/apps/gameplay/tests/test_questions.py
+++ b/backend/apps/gameplay/tests/test_questions.py
@@ -21,7 +21,7 @@ def test_create_dare_question_in_strange_habits_category():
     data = {
         "text": "Do 10 squats while repeating your favorite weird word.",
         "question_type": "dare",
-        "category": category.id
+        "category_id": category.id
     }
 
     response = client.post("/api/questions/", data, format='json')

--- a/backend/apps/gameplay/tests/test_random_questions.py
+++ b/backend/apps/gameplay/tests/test_random_questions.py
@@ -33,7 +33,7 @@ def test_random_questions_selection():
 
     for question in response.data:
         assert question["question_type"] == "truth"
-        assert question["category"] == category.id
+        assert question["category_id"] == category.id
         assert "text" in question and question["text"].startswith("Is it true")
 
     assert all(q["id"] not in request_data["excluded_ids"] for q in response.data)

--- a/docs/api.md
+++ b/docs/api.md
@@ -70,13 +70,13 @@ All endpoints below are relative to the base URL.
     "id": 17,
     "text": "Do 10 pushups.",
     "question_type": "dare",
-    "category": 1
+    "category_id": 1
   },
   {
     "id": 19,
     "text": "Sing a song loudly in the room.",
     "question_type": "dare",
-    "category": 2
+    "category_id": 2
   }
 ]
 ```
@@ -85,7 +85,8 @@ All endpoints below are relative to the base URL.
 > If fewer matching questions are available (e.g., only 2 meet the filters), then fewer will be returned.
 
 - `question_type` — `"truth"` or `"dare"`
-- `category_ids` — List of category IDs
+- `category_ids` — List of category IDs (request filter)
+- `category_id` - ID of the category this question belongs to (response)
 - `excluded_ids` — Optional; list of already shown question IDs
 
 ---


### PR DESCRIPTION
## Summary
Replaced `category` with `category_id` for the Question API (read & write).  
Removed the `category` field from responses.

## Changes
- Serializer: expose only `category_id` (mapped to model field `category`).
- Tests: updated to assert and send `category_id`.
- Documentation: updated examples and field descriptions.

## Why
Align API naming with DB field (`category_id`) and remove ambiguity.  

## Breaking Change
Clients must now use `category_id` instead of `category`.

## Checklist
- [x] Unit tests updated and passing (`pytest -q`)
- [x] Documentation updated
- [x] Verified with Postman (manual test)