### PR TITLE
chore(deps): remove redundant psycopg2 dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,6 @@ asgiref==3.8.1
 Django==5.1.6
 djangorestframework==3.15.2
 pillow==11.2.1
-psycopg2==2.9.10
 psycopg2-binary==2.9.10
 python-dotenv==1.0.1
 sqlparse==0.5.3


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                
  - Removed the duplicate `psycopg2` dependency from `backend/requirements.txt`, keeping only `psycopg2-binary`.

  ## Notes
  - `psycopg2-binary` ships a precompiled C extension, so installing the project no longer requires `pg_config` or a C toolchain.
  - No code, settings, or migration changes — Django keeps using the `django.db.backends.postgresql` engine, which is satisfied by `psycopg2-binary` alone.
