### PR TITLE
ci: add GitHub Actions workflow running pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: pytest
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_DB: truth_or_dare_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      SECRET_KEY: ci-secret-key
+      DEBUG: 'False'
+      ALLOWED_HOSTS: localhost,127.0.0.1
+      DB_NAME: truth_or_dare_db
+      DB_USER: postgres
+      DB_PASSWORD: postgres
+      DB_HOST: localhost
+      DB_PORT: '5432'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: backend/requirements-dev.txt
+
+      - name: Install dependencies
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Run tests
+        working-directory: backend
+        run: pytest apps/gameplay/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 🎯 Truth or Dare
 
+[![CI](https://github.com/tigdav/truth-or-dare/actions/workflows/ci.yml/badge.svg)](https://github.com/tigdav/truth-or-dare/actions/workflows/ci.yml)
+
 ![Python](https://img.shields.io/badge/Python-3.11.2-blue?logo=python&style=flat-square)
 ![Django](https://img.shields.io/badge/Django-5.1.6-%234092E5?logo=django&logoColor=white&style=flat-square)
 ![DRF](https://img.shields.io/badge/DRF-3.15.2-%23456394?logo=django&logoColor=white&style=flat-square)
@@ -149,13 +151,13 @@ is provided in a separate document: [docs/api.md](./docs/api.md).
 
 ## 🧪 Running Tests
 
-Using Django's test runner:
+Install development dependencies first (includes runtime requirements plus `pytest` and `pytest-django`):
 
 ```bash
-python manage.py test
+pip install -r requirements-dev.txt
 ```
 
-Or with Pytest:
+Then run the tests with Pytest:
 
 ```bash
 pytest apps/gameplay/

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+pytest-django==4.9.0


### PR DESCRIPTION
## Summary
- Added `.github/workflows/ci.yml` running `pytest apps/gameplay/` on push and pull requests targeting `main`.
- Added `backend/requirements-dev.txt` with pinned `pytest` and `pytest-django` dependencies.
- Added a CI status badge to the README and updated Running Tests to use Pytest.

## Notes
- CI-only and documentation/dependency setup change.
- No application code, settings, models, serializers, or migrations changed.