### PR TITLE
test(gameplay): expand permission, validation, and rules coverage

### DIFF
--- a/backend/apps/gameplay/tests/test_categories.py
+++ b/backend/apps/gameplay/tests/test_categories.py
@@ -32,3 +32,76 @@ def test_create_category():
     assert response.data["name"] == data["name"]
     assert response.data["description"] == data["description"]
     assert response.data["is_adult"] == data["is_adult"]
+
+
+@pytest.mark.django_db
+def test_anonymous_can_list_categories():
+    QuestionCategory.objects.create(
+        name="Public Category",
+        description="Listed for anonymous clients.",
+        is_adult=False
+    )
+    client = APIClient()
+
+    response = client.get("/api/categories/")
+
+    assert response.status_code == 200
+    assert len(response.data) == 1
+
+
+@pytest.mark.django_db
+def test_anonymous_can_retrieve_category():
+    category = QuestionCategory.objects.create(
+        name="Retrievable",
+        description="Detail view is public.",
+        is_adult=False
+    )
+    client = APIClient()
+
+    response = client.get(f"/api/categories/{category.id}/")
+
+    assert response.status_code == 200
+    assert response.data["name"] == "Retrievable"
+
+
+@pytest.mark.django_db
+def test_non_admin_cannot_create_category():
+    User.objects.create_user(username='alice', password='alicepass')
+    client = APIClient()
+    client.login(username='alice', password='alicepass')
+
+    data = {
+        "name": "Forbidden",
+        "description": "Should not be created by a non-admin user.",
+        "is_adult": False
+    }
+    response = client.post("/api/categories/", data, format='json')
+
+    assert response.status_code == 403
+    assert QuestionCategory.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_admin_can_update_category():
+    category = QuestionCategory.objects.create(
+        name="Original",
+        description="Before update.",
+        is_adult=False
+    )
+
+    User.objects.create_user(username='admin', password='adminpass', is_staff=True)
+    client = APIClient()
+    client.login(username='admin', password='adminpass')
+
+    data = {
+        "name": "Updated",
+        "description": "After update.",
+        "is_adult": True
+    }
+    response = client.put(f"/api/categories/{category.id}/", data, format='json')
+
+    assert response.status_code == 200
+
+    category.refresh_from_db()
+    assert category.name == "Updated"
+    assert category.is_adult is True

--- a/backend/apps/gameplay/tests/test_questions.py
+++ b/backend/apps/gameplay/tests/test_questions.py
@@ -38,3 +38,46 @@ def test_create_dare_question_in_strange_habits_category():
 
     assert "id" in response.data
     assert response.data["text"] == data["text"]
+
+
+@pytest.mark.django_db
+def test_anonymous_cannot_list_questions():
+    client = APIClient()
+
+    response = client.get("/api/questions/")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_non_admin_cannot_list_questions():
+    User.objects.create_user(username='alice', password='alicepass')
+    client = APIClient()
+    client.login(username='alice', password='alicepass')
+
+    response = client.get("/api/questions/")
+
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_admin_can_list_questions():
+    category = QuestionCategory.objects.create(
+        name="Listable",
+        description="Questions can be listed for admins.",
+        is_adult=False
+    )
+    Question.objects.create(
+        text="Sample listed question?",
+        question_type="truth",
+        category=category
+    )
+
+    User.objects.create_user(username='admin', password='adminpass', is_staff=True)
+    client = APIClient()
+    client.login(username='admin', password='adminpass')
+
+    response = client.get("/api/questions/")
+
+    assert response.status_code == 200
+    assert len(response.data) == 1

--- a/backend/apps/gameplay/tests/test_random_questions.py
+++ b/backend/apps/gameplay/tests/test_random_questions.py
@@ -37,3 +37,122 @@ def test_random_questions_selection():
         assert "text" in question and question["text"].startswith("Is it true")
 
     assert all(q["id"] not in request_data["excluded_ids"] for q in response.data)
+
+
+@pytest.mark.django_db
+def test_random_questions_excludes_specified_ids():
+    category = QuestionCategory.objects.create(
+        name="Mixed",
+        description="Holds multiple truth questions.",
+        is_adult=False
+    )
+    questions = [
+        Question.objects.create(
+            text=f"Truth statement {i}?",
+            question_type="truth",
+            category=category
+        )
+        for i in range(8)
+    ]
+    excluded = [questions[0].id, questions[1].id, questions[2].id]
+
+    client = APIClient()
+    request_data = {
+        "question_type": "truth",
+        "category_ids": [category.id],
+        "excluded_ids": excluded,
+    }
+    response = client.post("/api/questions/random/", request_data, format='json')
+
+    assert response.status_code == 200
+    returned_ids = [q["id"] for q in response.data]
+    assert all(qid not in excluded for qid in returned_ids)
+
+
+@pytest.mark.django_db
+def test_random_questions_filters_by_type():
+    category = QuestionCategory.objects.create(
+        name="Mixed Types",
+        description="Has both truth and dare questions.",
+        is_adult=False
+    )
+    for i in range(5):
+        Question.objects.create(
+            text=f"Truth {i}",
+            question_type="truth",
+            category=category
+        )
+    for i in range(5):
+        Question.objects.create(
+            text=f"Dare {i}",
+            question_type="dare",
+            category=category
+        )
+
+    client = APIClient()
+    request_data = {
+        "question_type": "dare",
+        "category_ids": [category.id],
+    }
+    response = client.post("/api/questions/random/", request_data, format='json')
+
+    assert response.status_code == 200
+    assert len(response.data) > 0
+    for q in response.data:
+        assert q["question_type"] == "dare"
+
+
+@pytest.mark.django_db
+def test_random_questions_returns_empty_when_no_match():
+    category = QuestionCategory.objects.create(
+        name="Truth Only",
+        description="Only truth questions exist here.",
+        is_adult=False
+    )
+    Question.objects.create(
+        text="Only truth here.",
+        question_type="truth",
+        category=category
+    )
+
+    client = APIClient()
+    request_data = {
+        "question_type": "dare",
+        "category_ids": [category.id],
+    }
+    response = client.post("/api/questions/random/", request_data, format='json')
+
+    assert response.status_code == 200
+    assert response.data == []
+
+
+@pytest.mark.django_db
+def test_random_questions_invalid_type_returns_400():
+    category = QuestionCategory.objects.create(
+        name="Validation",
+        description="Used for validation testing.",
+        is_adult=False
+    )
+
+    client = APIClient()
+    request_data = {
+        "question_type": "invalid",
+        "category_ids": [category.id],
+    }
+    response = client.post("/api/questions/random/", request_data, format='json')
+
+    assert response.status_code == 400
+    assert "question_type" in response.data
+
+
+@pytest.mark.django_db
+def test_random_questions_empty_categories_returns_400():
+    client = APIClient()
+    request_data = {
+        "question_type": "truth",
+        "category_ids": [],
+    }
+    response = client.post("/api/questions/random/", request_data, format='json')
+
+    assert response.status_code == 400
+    assert "category_ids" in response.data

--- a/backend/apps/gameplay/tests/test_rules.py
+++ b/backend/apps/gameplay/tests/test_rules.py
@@ -1,5 +1,6 @@
 import pytest
 from rest_framework.test import APIClient
+from django.contrib.auth.models import User
 
 from apps.gameplay.models import Rule
 
@@ -44,7 +45,10 @@ def test_rules_listed_in_order_field():
 
 @pytest.mark.django_db
 def test_rules_endpoint_does_not_allow_write():
+    User.objects.create_user(username='admin', password='adminpass', is_staff=True)
     client = APIClient()
+    client.login(username='admin', password='adminpass')
+
     response = client.post("/api/rules/", {"text": "Should not work"}, format='json')
 
     assert response.status_code == 405

--- a/backend/apps/gameplay/tests/test_rules.py
+++ b/backend/apps/gameplay/tests/test_rules.py
@@ -1,0 +1,50 @@
+import pytest
+from rest_framework.test import APIClient
+
+from apps.gameplay.models import Rule
+
+
+@pytest.mark.django_db
+def test_anonymous_can_list_rules():
+    Rule.objects.create(text="Rule one.", order=0)
+    Rule.objects.create(text="Rule two.", order=1)
+
+    client = APIClient()
+    response = client.get("/api/rules/")
+
+    assert response.status_code == 200
+    assert len(response.data) == 2
+
+
+@pytest.mark.django_db
+def test_rule_response_only_contains_text_field():
+    Rule.objects.create(text="Some rule.", order=0)
+
+    client = APIClient()
+    response = client.get("/api/rules/")
+
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert set(response.data[0].keys()) == {"text"}
+
+
+@pytest.mark.django_db
+def test_rules_listed_in_order_field():
+    Rule.objects.create(text="Third", order=3)
+    Rule.objects.create(text="First", order=1)
+    Rule.objects.create(text="Second", order=2)
+
+    client = APIClient()
+    response = client.get("/api/rules/")
+
+    assert response.status_code == 200
+    texts = [rule["text"] for rule in response.data]
+    assert texts == ["First", "Second", "Third"]
+
+
+@pytest.mark.django_db
+def test_rules_endpoint_does_not_allow_write():
+    client = APIClient()
+    response = client.post("/api/rules/", {"text": "Should not work"}, format='json')
+
+    assert response.status_code == 405


### PR DESCRIPTION
## Summary
- Added gameplay API tests for permissions, request validation, random question filtering, and rules endpoint behavior.
- Covered public/admin access boundaries for question and category endpoints.
- Added Rule API coverage for public reads, ordering, response fields, and write restrictions.

## Notes
- Test-only change.
- No application code, API, settings, dependency, or migration changes.
- Existing tests are preserved.