### PR TITLE
chore(deps): upgrade Django to 5.2 LTS and DRF to 3.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![CI](https://github.com/tigdav/truth-or-dare/actions/workflows/ci.yml/badge.svg)](https://github.com/tigdav/truth-or-dare/actions/workflows/ci.yml)
 
 ![Python](https://img.shields.io/badge/Python-3.11.2-blue?logo=python&style=flat-square)
-![Django](https://img.shields.io/badge/Django-5.1.6-%234092E5?logo=django&logoColor=white&style=flat-square)
-![DRF](https://img.shields.io/badge/DRF-3.15.2-%23456394?logo=django&logoColor=white&style=flat-square)
+![Django](https://img.shields.io/badge/Django-5.2.15-%234092E5?logo=django&logoColor=white&style=flat-square)
+![DRF](https://img.shields.io/badge/DRF-3.16.1-%23456394?logo=django&logoColor=white&style=flat-square)
 
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13%2B-%234983db?logo=postgresql&logoColor=white&style=flat-square)
 ![dotenv](https://img.shields.io/badge/python--dotenv-1.0.1-%23E64398?logo=python&logoColor=white&style=flat-square)
@@ -52,8 +52,8 @@ interface.
 ## Tech Stack
 
 - Python 3.11.2
-- Django 5.1.6
-- Django REST Framework 3.15.2
+- Django 5.2.15
+- Django REST Framework 3.16.1
 - PostgreSQL (via `psycopg2` 2.9.10)  
   _Can be swapped to SQLite, MySQL, or another Django‑supported engine by updating the `DATABASES` settings
   in `settings.py` or your `.env`._

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.8.1
-Django==5.1.6
-djangorestframework==3.15.2
+Django==5.2.15
+djangorestframework==3.16.1
 pillow==11.2.1
 psycopg2-binary==2.9.10
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- Upgraded Django from 5.1.6 to 5.2.15 (LTS). Django 5.1 reached end of security support on 2025-12-03; 5.2 LTS is supported through 2028-04-30.
- Upgraded Django REST Framework from 3.15.2 to 3.16.1, the first release line with official Django 5.2 support.
- Updated the Django and DRF version badges and the Tech Stack section in the README.

## Notes
- Dependency bump only. No application code, API, settings, or migration changes.
- Verified locally on the new versions: `manage.py check` passes, `makemigrations --check` reports no changes, and all tests pass with deprecation warnings treated as errors.