### PR TITLE
ci: upgrade Postgres service to 16 for Django 5.2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13
+        image: postgres:16
         env:
           POSTGRES_DB: truth_or_dare_db
           POSTGRES_USER: postgres

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Django](https://img.shields.io/badge/Django-5.2.15-%234092E5?logo=django&logoColor=white&style=flat-square)
 ![DRF](https://img.shields.io/badge/DRF-3.16.1-%23456394?logo=django&logoColor=white&style=flat-square)
 
-![PostgreSQL](https://img.shields.io/badge/PostgreSQL-13%2B-%234983db?logo=postgresql&logoColor=white&style=flat-square)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-14%2B-%234983db?logo=postgresql&logoColor=white&style=flat-square)
 ![dotenv](https://img.shields.io/badge/python--dotenv-1.0.1-%23E64398?logo=python&logoColor=white&style=flat-square)
 
 ![License](https://img.shields.io/badge/License-MIT-brightgreen?style=flat-square)


### PR DESCRIPTION
## Summary
- Bumped the CI PostgreSQL service image from `postgres:13` to `postgres:16`.
- Updated the PostgreSQL version badge in the README from 13+ to 14+.

## Notes
- Fixes the CI failures introduced by #10: Django 5.2 raised the minimum supported PostgreSQL version to 14, so the `postgres:13` service caused `NotSupportedError: PostgreSQL 14 or later is required` for every DB test.
- CI-only and documentation change. No application code, settings, or migration changes.
- Verified locally against a real `postgres:16` container replicating the CI service: all 19 tests pass.