### PR TITLE
chore(deps): add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Python dependencies (requirements.txt / requirements-dev.txt)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions used in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(deps)"


### PR DESCRIPTION
## Summary
- Added `.github/dependabot.yml` to enable automated dependency update PRs.
- Configured two ecosystems on a weekly schedule: `pip` (Python deps under `/backend`) and `github-actions` (workflow actions).

## Notes
- Configuration-only change. No application code, settings, or CI workflow changes.
- Commit-message prefixes are aligned with this repo's convention (`chore(deps)` for Python, `ci(deps)` for Actions).
- Dependabot will surface security and version updates as individual PRs, complementing the recent manual Django 5.2 / Postgres 16 upgrades.