### PR TITLE
ci: add Ruff lint check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
+      - name: Lint with Ruff
+        working-directory: backend
+        run: ruff check .
+
       - name: Run tests
         working-directory: backend
         run: pytest apps/gameplay/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+extend-exclude = ["*/migrations/*"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "B", "UP", "C4", "SIM"]

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest==8.3.4
 pytest-django==4.9.0
+ruff==0.15.16


### PR DESCRIPTION
## Summary
- Added `ruff` (pinned) to `requirements-dev.txt`.
- Added `backend/pyproject.toml` with a `[tool.ruff]` configuration: line length 120, target Python 3.11, auto-generated migrations excluded, and a curated lint rule set (`E`, `F`, `W`, `B`, `UP`, `C4`, `SIM`).
- Added a Ruff lint step to the CI workflow that runs `ruff check .` before the tests.

## Notes
- Linting only — no application code was reformatted or modified. The current codebase already passes `ruff check .` cleanly under this configuration.
- The rule set was chosen so it passes on the existing code without changes; import sorting (`I`) and stricter line length were intentionally left out to avoid touching source in this PR.
- Verified locally with the pinned ruff version: `ruff check .` exits 0.
