### PR TITLE
ci: bump checkout and setup-python actions to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,10 +37,10 @@ jobs:
       DB_PORT: '5432'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: pip


### PR DESCRIPTION
## Summary
- Bumped `actions/checkout` from v4 to v6.
- Bumped `actions/setup-python` from v5 to v6.

## Notes
- Clears the Node.js 20 deprecation warning (GitHub Actions is moving runners to Node 24); no workflow logic changes.
- The pip cache stays handled by `setup-python` (`cache: pip`), so no separate `actions/cache` bump is needed.
